### PR TITLE
fix(keymanager): fixed bug which would cause crash when no fueling keys are left

### DIFF
--- a/ts/fuelAgent.ts
+++ b/ts/fuelAgent.ts
@@ -22,6 +22,11 @@ export class FuelService {
     value = config.amount,
     sourceKey = this.keyManager.getKey(),
   ): Promise<void | TransactionReceipt> {
+    if (!sourceKey) {
+      debug(`Ran out of keys, can't send funds`)
+      throw new Error('Faucet currently empty')
+    }
+
     debug(`Request for fueling address - ${to}, with ${value} ETH`)
     const wallet = new Wallet(sourceKey, this.provider)
     return wallet

--- a/ts/keyManager.ts
+++ b/ts/keyManager.ts
@@ -17,7 +17,9 @@ export class KeyManager {
 
   getKey(): string {
     const first = this.keys.shift()
-    this.keys.push(first)
+    if (first) {
+      this.keys.push(first)
+    }
     return first
   }
 


### PR DESCRIPTION
In case we run out of keys, throw an error, also make sure we don't attempt to rotate keys if the
array is empty.